### PR TITLE
Improve the clarity of the FDTI orientation

### DIFF
--- a/esp8266.brd
+++ b/esp8266.brd
@@ -8,28 +8,28 @@
 </settings>
 <grid distance="0.025" unitdist="inch" unit="inch" style="dots" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
-<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="1" name="Top" color="4" fill="1" visible="no" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
 <layer number="17" name="Pads" color="2" fill="1" visible="no" active="yes"/>
 <layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="no" active="yes"/>
 <layer number="21" name="tPlace" color="7" fill="1" visible="no" active="yes"/>
-<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="no" active="yes"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
-<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="yes" active="yes"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
-<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="yes" active="yes"/>
 <layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
-<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="yes" active="yes"/>
 <layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
-<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="yes" active="yes"/>
 <layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
 <layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
 <layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
@@ -3243,8 +3243,8 @@ Please make sure your boards conform to these design rules.</description>
 <contactref element="JP3" pad="7"/>
 <contactref element="ESP8266-07/12" pad="15"/>
 <contactref element="U1" pad="1"/>
-<wire x1="22.86" y1="66.8274" x2="23.5458" y2="66.8274" width="0.1524" layer="16"/>
-<wire x1="22.86" y1="70.485" x2="22.86" y2="66.8274" width="0.1524" layer="1"/>
+<wire x1="22.86" y1="67.564" x2="23.5458" y2="66.8274" width="0.1524" layer="16"/>
+<wire x1="22.86" y1="70.485" x2="22.86" y2="67.564" width="0.1524" layer="1"/>
 <wire x1="28.2702" y1="75.8952" x2="25.7175" y2="73.3425" width="0.1524" layer="1"/>
 <wire x1="25.7175" y1="73.3425" x2="22.86" y2="70.485" width="0.1524" layer="1"/>
 <wire x1="30.7086" y1="75.8952" x2="28.2702" y2="75.8952" width="0.1524" layer="1"/>
@@ -3253,7 +3253,7 @@ Please make sure your boards conform to these design rules.</description>
 <wire x1="30.9372" y1="76.1238" x2="30.995" y2="76.16" width="0.1524" layer="1"/>
 <wire x1="31.0134" y1="76.2" x2="31.242" y2="76.4286" width="0.1524" layer="1"/>
 <wire x1="31.0134" y1="76.2" x2="30.995" y2="76.16" width="0.1524" layer="1"/>
-<via x="22.86" y="66.8274" extent="1-16" drill="0.3302"/>
+<via x="22.86" y="67.564" extent="1-16" drill="0.3302"/>
 <wire x1="35.052" y1="77.4192" x2="35.433" y2="77.4192" width="0.1524" layer="1"/>
 <wire x1="33.8328" y1="76.2" x2="35.052" y2="77.4192" width="0.1524" layer="1"/>
 <wire x1="31.3944" y1="76.2" x2="33.8328" y2="76.2" width="0.1524" layer="1"/>
@@ -3356,9 +3356,9 @@ Please make sure your boards conform to these design rules.</description>
 <wire x1="26.3652" y1="69.2658" x2="29.1846" y2="72.0852" width="0.1524" layer="1"/>
 <wire x1="23.7744" y1="69.2658" x2="26.3652" y2="69.2658" width="0.1524" layer="1"/>
 <wire x1="23.3934" y1="68.8848" x2="23.7744" y2="69.2658" width="0.1524" layer="1"/>
-<wire x1="23.3934" y1="67.1322" x2="23.3934" y2="68.8848" width="0.1524" layer="1"/>
-<wire x1="23.4696" y1="67.056" x2="23.3934" y2="67.1322" width="0.1524" layer="1"/>
-<wire x1="23.4696" y1="64.77" x2="23.4696" y2="67.056" width="0.1524" layer="1"/>
+<wire x1="23.3934" y1="68.4022" x2="23.3934" y2="68.8848" width="0.1524" layer="1"/>
+<wire x1="23.4696" y1="68.326" x2="23.3934" y2="68.4022" width="0.1524" layer="1"/>
+<wire x1="23.4696" y1="64.77" x2="23.4696" y2="68.326" width="0.1524" layer="1"/>
 <wire x1="19.8882" y1="61.1886" x2="23.4696" y2="64.77" width="0.1524" layer="1"/>
 <wire x1="19.5834" y1="61.1886" x2="19.8882" y2="61.1886" width="0.1524" layer="1"/>
 <wire x1="19.05" y1="60.6552" x2="19.5834" y2="61.1886" width="0.1524" layer="1"/>
@@ -3654,10 +3654,6 @@ Please make sure your boards conform to these design rules.</description>
 <wire x1="26.5176" y1="70.2564" x2="25.6032" y2="69.342" width="0.508" layer="16"/>
 <wire x1="25.6032" y1="66.8274" x2="25.538" y2="66.775" width="0.508" layer="16"/>
 <wire x1="26.5176" y1="70.2564" x2="26.543" y2="70.297" width="0.508" layer="16"/>
-<wire x1="22.098" y1="67.1322" x2="22.0218" y2="67.1322" width="0.508" layer="16"/>
-<wire x1="22.0218" y1="67.1322" x2="18.8976" y2="67.1322" width="0.508" layer="16"/>
-<wire x1="22.86" y1="67.8942" x2="22.098" y2="67.1322" width="0.508" layer="16"/>
-<wire x1="25.6032" y1="67.8942" x2="22.86" y2="67.8942" width="0.508" layer="16"/>
 <wire x1="27.8892" y1="71.5518" x2="27.8892" y2="75.6666" width="0.508" layer="16"/>
 <wire x1="26.7462" y1="70.4088" x2="27.8892" y2="71.5518" width="0.508" layer="16"/>
 <wire x1="27.8892" y1="75.6666" x2="27.9654" y2="75.8952" width="0.508" layer="16"/>
@@ -3669,7 +3665,6 @@ Please make sure your boards conform to these design rules.</description>
 <wire x1="15.9258" y1="64.0842" x2="15.9258" y2="63.8556" width="0.508" layer="1"/>
 <wire x1="14.6304" y1="60.0456" x2="14.6558" y2="60.005" width="0.508" layer="1"/>
 <wire x1="15.9258" y1="64.0842" x2="15.995" y2="64.16" width="0.508" layer="1"/>
-<wire x1="22.0218" y1="57.7596" x2="22.0218" y2="67.1322" width="0.508" layer="16"/>
 <wire x1="21.7932" y1="57.531" x2="22.0218" y2="57.7596" width="0.508" layer="16"/>
 <wire x1="35.5092" y1="60.0456" x2="34.29" y2="60.0456" width="0.508" layer="1"/>
 <wire x1="34.29" y1="60.0456" x2="33.0708" y2="60.0456" width="0.508" layer="1"/>
@@ -3714,6 +3709,17 @@ Please make sure your boards conform to these design rules.</description>
 <wire x1="22.86" y1="55.626" x2="22.86" y2="55.56" width="0.508" layer="16"/>
 <wire x1="21.9456" y1="56.5404" x2="21.717" y2="56.5404" width="0.508" layer="16"/>
 <wire x1="21.717" y1="56.5404" x2="21.7932" y2="56.6928" width="0.508" layer="16"/>
+<wire x1="23.622" y1="67.8942" x2="25.6032" y2="67.8942" width="0.508" layer="16"/>
+<wire x1="23.1648" y1="68.3514" x2="23.622" y2="67.8942" width="0.508" layer="16"/>
+<wire x1="22.5552" y1="68.3514" x2="23.1648" y2="68.3514" width="0.508" layer="16"/>
+<wire x1="21.8694" y1="67.6656" x2="22.5552" y2="68.3514" width="0.508" layer="16"/>
+<wire x1="21.8694" y1="67.437" x2="21.8694" y2="67.6656" width="0.508" layer="16"/>
+<wire x1="21.5646" y1="67.1322" x2="21.8694" y2="67.437" width="0.508" layer="16"/>
+<wire x1="18.8976" y1="67.1322" x2="21.5646" y2="67.1322" width="0.508" layer="16"/>
+<wire x1="21.6408" y1="66.3702" x2="21.6408" y2="66.9036" width="0.508" layer="16"/>
+<wire x1="22.0218" y1="65.9892" x2="21.6408" y2="66.3702" width="0.508" layer="16"/>
+<wire x1="22.0218" y1="57.7596" x2="22.0218" y2="65.9892" width="0.508" layer="16"/>
+<wire x1="21.6408" y1="66.9036" x2="21.5646" y2="67.1322" width="0.508" layer="16"/>
 </signal>
 <signal name="RXLED">
 <contactref element="U1" pad="22"/>


### PR DESCRIPTION
This was accomplish by moving the via a to a higher position so that it doesn't interfere with the markings.
